### PR TITLE
fix import error

### DIFF
--- a/notebooks/vevo_100m_pca.ipynb
+++ b/notebooks/vevo_100m_pca.ipynb
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f41d220a-5bc4-4824-8c57-c4dd107ba3be",
    "metadata": {
     "tags": []
@@ -542,7 +542,7 @@
     "\n",
     "    import rmm\n",
     "    import cupy as cp\n",
-    "    from cupyx.scipy import spx\n",
+    "    from cupyx.scipy import sparse as spx\n",
     "\n",
     "    from rmm.allocators.cupy import rmm_cupy_allocator\n",
     "\n",


### PR DESCRIPTION
Fix ImportError: spx is not a module in cupyx.scipy

`from cupyx.scipy import spx`

The spx module does not exist in cupyx.scipy, and this import will raise the following error:

`ImportError: cannot import name 'spx' from 'cupyx.scipy'`
## Changes


`from cupyx.scipy import sparse as spx`

